### PR TITLE
Make 400khz speed default for MPU sensors

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -56,20 +56,20 @@
   #define IMU_HAS_ACCELL true
   #define IMU_HAS_GYRO true
   #define IMU_HAS_MAG true
-  #define I2C_SPEED 100000
+  #define I2C_SPEED 400000
 #elif IMU == IMU_MPU6050
   #define IMU_NAME "MPU6050"
   #define IMU_HAS_ACCELL true
   #define IMU_HAS_GYRO true
   #define IMU_HAS_MAG false
-  #define I2C_SPEED 100000 // If you want to use dual MPU6050's, change I2C_SPEED to 400000
+  #define I2C_SPEED 400000
   #define IMU_MPU6050_RUNTIME_CALIBRATION // Comment to revert to startup/traditional-calibration
 #elif IMU == IMU_MPU6500
   #define IMU_NAME "MPU6500"
   #define IMU_HAS_ACCELL true
   #define IMU_HAS_GYRO true
   #define IMU_HAS_MAG false
-  #define I2C_SPEED 100000 // If you want to use dual MPU6050's, change I2C_SPEED to 400000
+  #define I2C_SPEED 400000
   #define IMU_MPU6050_RUNTIME_CALIBRATION // Comment to revert to startup/traditional-calibration
 #else
     #error Select IMU in defines.h


### PR DESCRIPTION
People tested and found that 400khz is more stable for MPUs also